### PR TITLE
fix of installation failure on non-AWS machines

### DIFF
--- a/config/kaveinstall.py
+++ b/config/kaveinstall.py
@@ -195,7 +195,13 @@ def df(filename, options=[]):
         output = _df.communicate()[0]
     except:
         raise OSError("Problem retrieving diskspace for " + filename)
-    return output.split("\n")[1].split()
+    by_lines=output.split("\n")
+    out=by_lines[1].split()
+    # fix for case output has several lines
+    for line in range(2,len(by_lines)):
+	out.extend(by_lines[line].split())
+    return out
+
 
 
 def installfrom():


### PR DESCRIPTION
On some machines, the name of the mount point is too long and then the command 
`df -i /dir`
can produce output on several lines, e.g.

```
Filesystem     Inodes  IUsed  IFree IUse% Mounted on
/dev/longlongname    
                       524288 172821 351467   33% /
```

This leads to an installation failure, as function `df(filename, options=[]):` assumes that the free space is the fourth input on the _second_ line. In a cases like above this leads to `index out of bounds` error, as the expected information is actually on the _third_ line.

The modified script was tested to successfully install kavetoolbox node on a centOS 6 system.
